### PR TITLE
Fixed debugging slides link in Revision.md

### DIFF
--- a/content/Revision/Revision.md
+++ b/content/Revision/Revision.md
@@ -58,7 +58,7 @@ math: true
 - Memory Management
   - [Pointers and Addressing](../PointersAndAddressing/PointersAndAddressing.html)
 - Debugging
-  - [Debugging](../Debugging/Debugging.htmls)
+  - [Debugging](../Debugging/Debugging.html)
 
 ---
 


### PR DESCRIPTION
Fixed debugging slides link in Revision.md, small typo.